### PR TITLE
Fix Wrong Statistical Terminology

### DIFF
--- a/lecture/4-preprocessing/4-data-reduction.tex
+++ b/lecture/4-preprocessing/4-data-reduction.tex
@@ -616,11 +616,11 @@
 			      \item There is an equal probability of selecting any particular
 			            item.
 		      \end{itemize}
-		\item \textbf{Sampling without repetition.}
+		\item \textbf{Sampling without replacement.}
 		      \begin{itemize}
 			      \item Once an object is selected, it is removed from the population.
 		      \end{itemize}
-		\item \textbf{Sampling with repetition.}
+		\item \textbf{Sampling with replacement.}
 		      \begin{itemize}
 			      \item A selected object is not removed from the population.
 		      \end{itemize}


### PR DESCRIPTION
The chapter on preprocessing introduces sampling and various types of sampling. However, the terminology stated in the slides differs to the statistical literature as well as with the book, this lecture is based on. More specifically, the slides introduces "sampling with/without repetition". Yet the concept is commonly referred to as "sampling with/without _replacement_". The original slides of Han also have the correct terminology (cf. PowerPoint slides of [preprocessing](http://hanj.cs.illinois.edu/bk3/bk3_slides/03Preprocessing.ppt) on slide 43).

Please also refer to the following literature:
- Han et al., Data Mining, 3rd Edition, chapter 3.4.8 on page 108
- Scheaffer et. al, Elementary Survey Sampling, 7th Edition, for instance chapter 3.3 on page 53, and other chapters sections
- Rohatgi and Saleh, An Introduction to Probability and Statistics, 3rd Edition, chapter 1.4 on page 21