### PR TITLE
Exercise 2.3: Extract and use the correct first Eigenvector

### DIFF
--- a/exercise/2-Data-Analysis-Preprocessing/2.3-Preprocessing-Data-Reduction-Transformation-and-Discretization.ipynb
+++ b/exercise/2-Data-Analysis-Preprocessing/2.3-Preprocessing-Data-Reduction-Transformation-and-Discretization.ipynb
@@ -1224,7 +1224,7 @@
    "source": [
     "# Select the feature matrix\n",
     "# The first eigenvector contains nearly all information => select only that one\n",
-    "feature_matrix = eigenvectors[1]\n",
+    "feature_matrix = eigenvectors[:, 0]\n",
     "\n",
     "# Print the feature_matrix\n",
     "feature_matrix"


### PR DESCRIPTION
Currently row one is used for eigenvector extraction in PCA in [Exercise 2.3: Task 15](https://github.com/FAU-CS6/KDD/blob/main/exercise/2-Data-Analysis-Preprocessing/2.3-Preprocessing-Data-Reduction-Transformation-and-Discretization.ipynb?short_path=004dd36#L1227), but we want to use the zeroth column of the same matrix (see [documentation](https://numpy.org/doc/stable/reference/generated/numpy.linalg.eig.html)).