### PR TITLE
Exercise-Classification: Selecting the correct eigenvector

### DIFF
--- a/exercise/2-Data-Analysis-Preprocessing/Data-Reduction-Transformation-and-Discretization.ipynb
+++ b/exercise/2-Data-Analysis-Preprocessing/Data-Reduction-Transformation-and-Discretization.ipynb
@@ -1078,6 +1078,11 @@
     "# Calculate the associated eigenvalues and eigenvectors\n",
     "eigenvalues, eigenvectors = np.linalg.eig(covariance_matrix)\n",
     "\n",
+    "# sort the eigenvalues and eigenvectors (so they are in increasing order)\n",
+    "idx = np.argsort(eigenvalues)\n",
+    "eigvals = eigenvalues[idx]\n",
+    "eigvecs = eigenvectors[:, idx]\n",
+    "\n",
     "# Display the eigenvalues and eigenvectors\n",
     "print(\"Eigenvalues:\")\n",
     "print(eigenvalues)\n",
@@ -1185,8 +1190,8 @@
    "outputs": [],
    "source": [
     "# Select the feature matrix\n",
-    "# The first eigenvector contains nearly all information => select only that one\n",
-    "feature_matrix = eigenvectors[:, 0]\n",
+    "# The largest eigenvector contains nearly all information => select only that one\n",
+    "feature_matrix = eigenvectors[:, 1]\n",
     "\n",
     "# Print the feature_matrix\n",
     "feature_matrix"


### PR DESCRIPTION
In Exercise-Classification the largest eigenvalue does not always have index 0.
Seems like this depends on the Numpy and Python versions.

Therefore I added some code that sorts the eigenvalues and eigenvectors in increasing order. This ensures the index 1 eigenvector is always the correct one to select.