### PR TITLE
Lecture-data: Fixed typo on slide 23

### DIFF
--- a/lecture/3-data/2-statistical-description.tex
+++ b/lecture/3-data/2-statistical-description.tex
@@ -403,7 +403,7 @@
 \begin{frame}{Measuring the Dispersion of Data (II)}
 	\begin{itemize}
 		\item \textbf{Range} is the difference between the largest and smallest value.
-		\item \textbf{Quartiles:} Also known as \textit{quantiles}. Generalization of the median. Median is the $50^{\text{th}}$ quartile.\\
+		\item \textbf{Quartiles:} Also known as \textit{quantiles}. Generalization of the median. Median is the $50^{\text{th}}$ percentile and the 2nd quartile ($Q_2$).\\
 		      Other common quartiles include $Q_1$ ($25^{\text{th}}$ percentile) and $Q_3$
 		      ($75^{\text{th}}$ percentile).\\\smallskip Quartile with order $p$ with
 		      ($0 < p < 1$) have following characteristics:


### PR DESCRIPTION
This change corrects a factual typo on the slide "Measuring the Dispersion of Data (II)". Under the Quartiles section, the original text incorrectly states: "Median is the 50th quartile".
Because quartiles divide data into four equal parts, there are only three (Q_1,Q_2,Q_3), making a "50th" quartile mathematically impossible. The intended meaning refers to the 50th percentile, which is consistent with the slide's correct labeling of Q_1 as the 25th percentile and Q_3 as the 75th percentile.

**Proposed Change:** Update the sentence to: "Median is the 50th percentile and the 2nd quartile (Q_2)."